### PR TITLE
Add Operation Plague Star specific Zaw Strikes

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -23,6 +23,7 @@ const acquisition = {
   CETUS_TIER_5: 'Cetus Bounty (Tier 5)',
   HOKS_ANVIL: 'Hok\'s Anvil (Cetus)',
   THE_QUILLS: 'The Quills (Cetus)',
+  NAKAK: 'Nakak (Cetus)',
 };
 
 const acquisitionQuests = {

--- a/src/data/zaw.js
+++ b/src/data/zaw.js
@@ -1,6 +1,6 @@
 const constants = require('../constants.js');
 
-const { HOKS_ANVIL } = constants.acquisition;
+const { HOKS_ANVIL, NAKAK } = constants.acquisition;
 
 module.exports = {
   zaw: [
@@ -10,5 +10,7 @@ module.exports = {
     { name: 'Kronsh Strike', acquisition: HOKS_ANVIL },
     { name: 'Mewan Strike', acquisition: HOKS_ANVIL },
     { name: 'Ooltha Strike', acquisition: HOKS_ANVIL },
+    { name: 'Plague Keewar Strike', acquisition: NAKAK },
+    { name: 'Plague Kripath Strike', acquisition: NAKAK },
   ],
 };


### PR DESCRIPTION
You might want to change the acquisition entry. Right now the Zaw Strikes are at Nakak in Cetus, but they're also associated with an operation that's time limited ... so I took a guess as to what acquisition value to use.