### PR TITLE
Update 22.17.2 and 22.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 👾 A list of all Warframe items that contribute to player mastery rank.
 
-[![warframe-item-list on npm](https://nodei.co/npm/warframe-item-list.png)](https://nodei.co/npm/warframe-item-list/)
+[![warframe-item-list on npm](https://nodei.co/npm/warframe-item-list.png)](https://www.npmjs.com/package/warframe-item-list)
 
-[![warframe update](https://img.shields.io/badge/warframe_update-22.17.2-blue.svg)](http://warframe.wikia.com/wiki/Update_22#Hotfix_22.17.2)
+[![warframe update](https://img.shields.io/badge/warframe_update-22.18.0-blue.svg)](http://warframe.wikia.com/wiki/Update_22#Update_22.18)
 [![Dependencies](https://david-dm.org/South-Paw/warframe-item-list/status.svg)](https://david-dm.org/South-Paw/warframe-item-list)
 [![Dev Dependencies](https://david-dm.org/South-Paw/warframe-item-list/dev-status.svg)](https://david-dm.org/South-Paw/warframe-item-list?type=dev)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![warframe-item-list on npm](https://nodei.co/npm/warframe-item-list.png)](https://nodei.co/npm/warframe-item-list/)
 
-[![warframe update](https://img.shields.io/badge/warframe_update-22.17.1.1-blue.svg)](http://warframe.wikia.com/wiki/Update_22#Hotfix_22.17.1.1)
+[![warframe update](https://img.shields.io/badge/warframe_update-22.17.2-blue.svg)](http://warframe.wikia.com/wiki/Update_22#Hotfix_22.17.2)
 [![Dependencies](https://david-dm.org/South-Paw/warframe-item-list/status.svg)](https://david-dm.org/South-Paw/warframe-item-list)
 [![Dev Dependencies](https://david-dm.org/South-Paw/warframe-item-list/dev-status.svg)](https://david-dm.org/South-Paw/warframe-item-list?type=dev)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "warframe-item-list",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warframe-item-list",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A list of all Warframe items that contribute to player mastery rank.",
   "keywords": [
     "warframe"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warframe-item-list",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A list of all Warframe items that contribute to player mastery rank.",
   "keywords": [
     "warframe"

--- a/src/constants.js
+++ b/src/constants.js
@@ -19,6 +19,7 @@ const acquisitions = {
   OROKIN_LAB: 'Orokin Lab (Dojo)',
   RAZORBACK_ARMADA: 'Razorback Armada',
   RELICS: 'Relics',
+  SANCTUARY_ONSLAUGHT: 'Sanctuary Onslaught',
   SPY_MISSIONS: 'Spy Missions',
   STALKER: 'Stalker',
   THE_QUILLS: 'The Quills (Cetus)',

--- a/src/data/companions.js
+++ b/src/data/companions.js
@@ -69,7 +69,7 @@ module.exports = {
     },
     {
       name: 'Wyrm Prime',
-      acquisition: RELICS,
+      acquisition: VAULTED,
       masteryRank: 0,
     },
   ],

--- a/src/data/warframes.js
+++ b/src/data/warframes.js
@@ -3,6 +3,7 @@ const constants = require('../constants.js');
 const {
   ALERTS,
   RELICS,
+  SANCTUARY_ONSLAUGHT,
   SPY_MISSIONS,
   TENNO_LAB,
   UNOBTAINABLE,
@@ -137,6 +138,11 @@ module.exports = {
     {
       name: 'Ivara',
       acquisition: SPY_MISSIONS,
+      masteryRank: 0,
+    },
+    {
+      name: 'Khora',
+      acquisition: SANCTUARY_ONSLAUGHT,
       masteryRank: 0,
     },
     {

--- a/src/data/warframes.js
+++ b/src/data/warframes.js
@@ -81,7 +81,7 @@ module.exports = {
     },
     {
       name: 'Ember Prime',
-      acquisition: RELICS,
+      acquisition: VAULTED,
       masteryRank: 0,
     },
     {
@@ -106,7 +106,7 @@ module.exports = {
     },
     {
       name: 'Frost Prime',
-      acquisition: RELICS,
+      acquisition: VAULTED,
       masteryRank: 0,
     },
     {
@@ -151,7 +151,7 @@ module.exports = {
     },
     {
       name: 'Loki Prime',
-      acquisition: RELICS,
+      acquisition: VAULTED,
       masteryRank: 0,
     },
     {

--- a/src/data/weapons.js
+++ b/src/data/weapons.js
@@ -246,7 +246,7 @@ module.exports = {
     },
     {
       name: 'Latron Prime',
-      acquisition: RELICS,
+      acquisition: VAULTED,
       category: RIFLE,
       masteryRank: 10,
     },
@@ -878,7 +878,7 @@ module.exports = {
     },
     {
       name: 'Sicarus Prime',
-      acquisition: RELICS,
+      acquisition: VAULTED,
       category: SINGLE_PISTOL,
       masteryRank: 14,
     },
@@ -1708,7 +1708,7 @@ module.exports = {
     },
     {
       name: 'Bo Prime',
-      acquisition: RELICS,
+      acquisition: VAULTED,
       category: STAFF,
       masteryRank: 5,
     },
@@ -1739,7 +1739,7 @@ module.exports = {
     {
       name: 'Glaive Prime',
       acquisition: RELICS,
-      category: GLAIVE,
+      category: VAULTED,
       masteryRank: 10,
     },
     {
@@ -1948,7 +1948,7 @@ module.exports = {
     },
     {
       name: 'Reaper Prime',
-      acquisition: RELICS,
+      acquisition: VAULTED,
       category: SCYTHE,
       masteryRank: 2,
     },

--- a/src/data/weapons.js
+++ b/src/data/weapons.js
@@ -557,6 +557,12 @@ module.exports = {
       masteryRank: 14,
     },
     {
+      name: 'Veldt',
+      acquisition: TENNO_LAB,
+      category: SNIPER,
+      masteryRank: 8,
+    },
+    {
       name: 'Vulkar',
       acquisition: MARKET,
       category: SNIPER,
@@ -791,6 +797,12 @@ module.exports = {
       acquisition: MARKET,
       category: SINGLE_PISTOL,
       masteryRank: 2,
+    },
+    {
+      name: 'Hystrix',
+      acquisition: MARKET,
+      category: SINGLE_PISTOL,
+      masteryRank: 7,
     },
     {
       name: 'Knell',
@@ -1375,6 +1387,12 @@ module.exports = {
       acquisition: MARKET,
       category: DUAL_SWORDS,
       masteryRank: 0,
+    },
+    {
+      name: 'Dual Keres',
+      acquisition: MARKET,
+      category: DUAL_SWORDS,
+      masteryRank: 7,
     },
     {
       name: 'Twin Krohkur',

--- a/src/data/zaws.js
+++ b/src/data/zaws.js
@@ -23,6 +23,11 @@ module.exports = {
       masteryRank: 0,
     },
     {
+      name: 'Dokrahm Strike',
+      acquisition: HOKS_ANVIL,
+      masteryRank: 0,
+    },
+    {
       name: 'Kronsh Strike',
       acquisition: HOKS_ANVIL,
       masteryRank: 0,
@@ -45,6 +50,16 @@ module.exports = {
     {
       name: 'Plague Kripath Strike',
       acquisition: NAKAK,
+      masteryRank: 0,
+    },
+    {
+      name: 'Rabvee Strike',
+      acquisition: HOKS_ANVIL,
+      masteryRank: 0,
+    },
+    {
+      name: 'Sepfahn Strike',
+      acquisition: HOKS_ANVIL,
       masteryRank: 0,
     },
   ],

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const { objects } = require('./object.js');
 const constants = require('./constants.js');
 
 module.exports = {
-  version: '22.17.2',
+  version: '22.18.0',
   array,
   objects,
   constants,

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const { objects } = require('./object.js');
 const constants = require('./constants.js');
 
 module.exports = {
-  version: '22.17.1.1',
+  version: '22.17.2',
   array,
   objects,
   constants,


### PR DESCRIPTION
* Update game version to 22.18.0
* Bump to v2.1.0

## Changes in 22.17.2

* Vaulted `Ember Prime`, `Sicarus Prime`, `Glaive Prime`, `Frost Prime`, `Latron Prime`, `Reaper Prime`, `Loki Prime`, `Bo Prime`, and `Wyrm Prime`.

## Changes in 22.18.0

* Add `Khora` warframe, `Veldt` sniper, `Hystrix` pistol and `Dual Keres` swords
* Add 3 new Zaw strikes; `Dokrahm`, `Rabvee` and `Sepfahn`